### PR TITLE
enhance: make attestation report struct public

### DIFF
--- a/sev-snp/src/lib.rs
+++ b/sev-snp/src/lib.rs
@@ -7,16 +7,16 @@ mod verifier;
 pub mod device;
 pub mod error;
 
+pub use sev::firmware::guest::AttestationReport;
+
+use crate::error::{Result, SevSnpError};
+use crate::utils::AttestationReportExt;
 use certs::CertificateChain;
 use device::{DerivedKeyOptions, Device, ReportOptions};
 use kds::KDS;
 use sev::certs::snp::Certificate;
-use sev::firmware::guest::AttestationReport;
 use sev::firmware::host::CertType;
 use std::collections::HashMap;
-
-use crate::error::{Result, SevSnpError};
-use crate::utils::AttestationReportExt;
 
 /// Indicate whether attestation verification should happen with
 /// certs retrieved from SEV-SNP device or KDS or custom.


### PR DESCRIPTION
## Description

Make the `AttestationReport` struct public. It is useful as a return type for verifying attestation report when leveraging this crate. 

Example:
```
pub fn get_parsed_attestation_report() -> Result<AttestationReport, Box<dyn std::error::Error>> {
    let sev_snp = SevSnp::new()?;
    let (report, _var_data) = sev_snp.get_attestation_report()?;
    Ok(report)
}
```