### PR TITLE
Fix typos in code comments

### DIFF
--- a/sev-snp/src/utils.rs
+++ b/sev-snp/src/utils.rs
@@ -5,7 +5,7 @@ use rand::RngCore;
 use std::{fs::File, fs::OpenOptions, io::Write, path::PathBuf};
 
 /// Generates 64 bytes of random data
-/// Always guaranted to return something (ie, unwrap() can be safely called)
+/// Always guaranteed to return something (ie, unwrap() can be safely called)
 pub fn generate_random_data() -> Option<[u8; 64]> {
     let mut data = [0u8; 64];
     rand::thread_rng().fill_bytes(&mut data);

--- a/zk/common/x509-verifier-rust-crypto/src/lib.rs
+++ b/zk/common/x509-verifier-rust-crypto/src/lib.rs
@@ -35,7 +35,7 @@ pub fn verify_x509_chain(cert_chain: &[X509Certificate]) -> bool {
 }
 
 fn verify_cert_issuer(subject: &X509Certificate, issuer: Option<&X509Certificate>) -> bool {
-    // the issuer param can be ommited,
+    // the issuer param can be omitted,
     // if and only if it signs its own certificate, e.g. a root certificate
     let current_issuer: &X509Certificate;
     match issuer {


### PR DESCRIPTION


## Description

This PR fixes minor typos in code comments across two files:

### Changes
- **`sev-snp/src/utils.rs`**: Fixed typo "guaranted" → "guaranteed" in line 8
- **`zk/common/x509-verifier-rust-crypto/src/lib.rs`**: Fixed typo "ommited" → "omitted" in line 38

