### PR TITLE
Fix `Succinct` typo in contract NatSpec docs

### DIFF
--- a/contracts/src/SEVAgentAttestation.sol
+++ b/contracts/src/SEVAgentAttestation.sol
@@ -148,7 +148,7 @@ contract SEVAgentAttestation is Ownable, CertCacheBase, ISnpAttestation {
     /**
      * @param zkCoProcessorType 1 - RiscZero, 2 - Succinct... etc.
      * @return this is either the IMAGE_ID for RiscZero Guest Program or
-     * Succiinct Program Verifying Key
+     * Succinct Program Verifying Key
      */
     function programIdentifier(ZkCoProcessorType zkCoProcessorType) external view override returns (bytes32) {
         return _zkConfig[zkCoProcessorType].latestProgramIdentifier;

--- a/contracts/src/interfaces/ISnpAttestation.sol
+++ b/contracts/src/interfaces/ISnpAttestation.sol
@@ -78,7 +78,7 @@ interface ISnpAttestation {
     /**
      * @param zkCoProcessorType 1 - RiscZero, 2 - Succinct, 3 - Pico... etc.
      * @return this is either the IMAGE_ID for RiscZero Guest Program or
-     * Succiinct Program Verifying Key
+     * Succinct Program Verifying Key
      */
     function programIdentifier(ZkCoProcessorType zkCoProcessorType) external view returns (bytes32);
 


### PR DESCRIPTION

- Correct a spelling typo in NatSpec: **“Succiinct” → “Succinct”**
