### PR TITLE
Add Ethereum address validation and refactor New(chainID) API

### DIFF
--- a/go-sdk/packages/gosev/registry/metadata.json
+++ b/go-sdk/packages/gosev/registry/metadata.json
@@ -22,8 +22,5 @@
     "rpc_endpoints": ["https://1rpc.io/ata/testnet", "https://rpc-testnet.ata.network"],
     "gas_price_hint_wei": 300,
     "block_explorers": ["https://explorer-testnet.ata.network/"]
-  },
-  "default": {
-    "network_key": "automata_testnet"
   }
 }

--- a/go-sdk/packages/gosev/registry/parser.go
+++ b/go-sdk/packages/gosev/registry/parser.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -69,44 +68,27 @@ func parseNetwork(key string, metadata *NetworkMetadata, sevData []byte) (*Netwo
 	}, nil
 }
 
-// MetadataConfig represents the full metadata JSON structure
-type MetadataConfig map[string]json.RawMessage
-
-// parseMetadata parses the metadata JSON
-func parseMetadata(data []byte) (map[string]*NetworkMetadata, string, error) {
-	var config MetadataConfig
-	if err := json.Unmarshal(data, &config); err != nil {
-		return nil, "", fmt.Errorf("failed to parse metadata: %w", err)
+// parseMetadata parses the metadata JSON and returns the entry matching chainID
+func parseMetadata(data []byte, chainID uint64) (string, *NetworkMetadata, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return "", nil, fmt.Errorf("failed to parse metadata: %w", err)
 	}
 
-	networks := make(map[string]*NetworkMetadata)
-	var defaultNetwork string
-
-	for key, raw := range config {
+	for key, rawMsg := range raw {
 		if key == "default" {
-			var defaultConfig struct {
-				NetworkKey string `json:"network_key"`
-			}
-			if err := json.Unmarshal(raw, &defaultConfig); err == nil {
-				defaultNetwork = defaultConfig.NetworkKey
-			}
 			continue
 		}
 
 		var meta NetworkMetadata
-		if err := json.Unmarshal(raw, &meta); err != nil {
-			continue // Skip invalid entries
+		if err := json.Unmarshal(rawMsg, &meta); err != nil {
+			return "", nil, fmt.Errorf("invalid metadata for network %q: %w", key, err)
 		}
-		networks[key] = &meta
+
+		if meta.ChainID == chainID {
+			return key, &meta, nil
+		}
 	}
 
-	return networks, defaultNetwork, nil
-}
-
-// normalizeNetworkKey converts various network key formats to the canonical form
-func normalizeNetworkKey(key string) string {
-	key = strings.ToLower(key)
-	key = strings.ReplaceAll(key, "-", "_")
-	key = strings.ReplaceAll(key, " ", "_")
-	return key
+	return "", nil, fmt.Errorf("network not found for chain ID: %d", chainID)
 }

--- a/go-sdk/packages/gosev/registry/parser.go
+++ b/go-sdk/packages/gosev/registry/parser.go
@@ -70,23 +70,14 @@ func parseNetwork(key string, metadata *NetworkMetadata, sevData []byte) (*Netwo
 
 // parseMetadata parses the metadata JSON and returns the entry matching chainID
 func parseMetadata(data []byte, chainID uint64) (string, *NetworkMetadata, error) {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
+	var networks map[string]*NetworkMetadata
+	if err := json.Unmarshal(data, &networks); err != nil {
 		return "", nil, fmt.Errorf("failed to parse metadata: %w", err)
 	}
 
-	for key, rawMsg := range raw {
-		if key == "default" {
-			continue
-		}
-
-		var meta NetworkMetadata
-		if err := json.Unmarshal(rawMsg, &meta); err != nil {
-			return "", nil, fmt.Errorf("invalid metadata for network %q: %w", key, err)
-		}
-
+	for key, meta := range networks {
 		if meta.ChainID == chainID {
-			return key, &meta, nil
+			return key, meta, nil
 		}
 	}
 

--- a/go-sdk/packages/gosev/registry/parser.go
+++ b/go-sdk/packages/gosev/registry/parser.go
@@ -36,6 +36,10 @@ func parseSevDeployment(data []byte) (*SevContracts, error) {
 		return nil, fmt.Errorf("VERIFIER address not found in deployment")
 	}
 
+	if !common.IsHexAddress(deployment.Verifier) {
+		return nil, fmt.Errorf("invalid VERIFIER address: %q", deployment.Verifier)
+	}
+
 	return &SevContracts{
 		Verifier: common.HexToAddress(deployment.Verifier),
 	}, nil

--- a/go-sdk/packages/gosev/registry/parser_test.go
+++ b/go-sdk/packages/gosev/registry/parser_test.go
@@ -1,0 +1,38 @@
+package registry
+
+import (
+	"testing"
+)
+
+func TestParseSevDeployment_ValidAddress(t *testing.T) {
+	data := []byte(`{"VERIFIER":"0x84d19f7F2e07766ea16D1c24f7e0828FA11273A2","remark":"test"}`)
+	contracts, err := parseSevDeployment(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "0x84d19f7F2e07766ea16D1c24f7e0828FA11273A2"
+	if contracts.Verifier.Hex() != expected {
+		t.Errorf("expected %s, got %s", expected, contracts.Verifier.Hex())
+	}
+}
+
+func TestParseSevDeployment_EmptyVerifier(t *testing.T) {
+	_, err := parseSevDeployment([]byte(`{"VERIFIER":"","remark":"test"}`))
+	if err == nil {
+		t.Fatal("expected error for empty verifier")
+	}
+}
+
+func TestParseSevDeployment_InvalidAddress(t *testing.T) {
+	_, err := parseSevDeployment([]byte(`{"VERIFIER":"not-a-valid-address"}`))
+	if err == nil {
+		t.Fatal("expected error for invalid address")
+	}
+}
+
+func TestParseSevDeployment_InvalidJSON(t *testing.T) {
+	_, err := parseSevDeployment([]byte(`{invalid}`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}

--- a/go-sdk/packages/gosev/registry/parser_test.go
+++ b/go-sdk/packages/gosev/registry/parser_test.go
@@ -36,3 +36,90 @@ func TestParseSevDeployment_InvalidJSON(t *testing.T) {
 		t.Fatal("expected error for invalid JSON")
 	}
 }
+
+func TestParseMetadata_Found(t *testing.T) {
+	data := []byte(`{
+		"eth_sepolia": {
+			"name": "Ethereum Sepolia",
+			"chain_id": 11155111,
+			"testnet": true,
+			"rpc_endpoints": ["https://1rpc.io/sepolia"]
+		},
+		"automata_testnet": {
+			"name": "Automata Testnet",
+			"chain_id": 1398243,
+			"testnet": true,
+			"rpc_endpoints": ["https://rpc-testnet.ata.network"]
+		},
+		"default": {
+			"network_key": "automata_testnet"
+		}
+	}`)
+
+	key, meta, err := parseMetadata(data, 11155111)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "eth_sepolia" {
+		t.Errorf("key = %q, want %q", key, "eth_sepolia")
+	}
+	if meta.ChainID != 11155111 {
+		t.Errorf("ChainID = %d, want 11155111", meta.ChainID)
+	}
+	if meta.Name != "Ethereum Sepolia" {
+		t.Errorf("Name = %q, want %q", meta.Name, "Ethereum Sepolia")
+	}
+}
+
+func TestParseMetadata_NotFound(t *testing.T) {
+	data := []byte(`{
+		"eth_sepolia": {
+			"name": "Ethereum Sepolia",
+			"chain_id": 11155111,
+			"testnet": true,
+			"rpc_endpoints": ["https://1rpc.io/sepolia"]
+		}
+	}`)
+
+	_, _, err := parseMetadata(data, 999999999)
+	if err == nil {
+		t.Fatal("expected error for unknown chain ID")
+	}
+}
+
+func TestParseMetadata_InvalidJSON(t *testing.T) {
+	_, _, err := parseMetadata([]byte(`{invalid}`), 11155111)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseMetadata_InvalidNetworkEntry(t *testing.T) {
+	data := []byte(`{
+		"eth_sepolia": "not-a-valid-network"
+	}`)
+
+	_, _, err := parseMetadata(data, 11155111)
+	if err == nil {
+		t.Fatal("expected error for invalid network entry")
+	}
+}
+
+func TestParseMetadata_IgnoresDefaultKey(t *testing.T) {
+	data := []byte(`{
+		"eth_sepolia": {
+			"name": "Ethereum Sepolia",
+			"chain_id": 11155111,
+			"testnet": true,
+			"rpc_endpoints": ["https://1rpc.io/sepolia"]
+		},
+		"default": {
+			"network_key": "eth_sepolia"
+		}
+	}`)
+
+	_, _, err := parseMetadata(data, 11155111)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/go-sdk/packages/gosev/registry/parser_test.go
+++ b/go-sdk/packages/gosev/registry/parser_test.go
@@ -50,9 +50,6 @@ func TestParseMetadata_Found(t *testing.T) {
 			"chain_id": 1398243,
 			"testnet": true,
 			"rpc_endpoints": ["https://rpc-testnet.ata.network"]
-		},
-		"default": {
-			"network_key": "automata_testnet"
 		}
 	}`)
 
@@ -105,21 +102,3 @@ func TestParseMetadata_InvalidNetworkEntry(t *testing.T) {
 	}
 }
 
-func TestParseMetadata_IgnoresDefaultKey(t *testing.T) {
-	data := []byte(`{
-		"eth_sepolia": {
-			"name": "Ethereum Sepolia",
-			"chain_id": 11155111,
-			"testnet": true,
-			"rpc_endpoints": ["https://1rpc.io/sepolia"]
-		},
-		"default": {
-			"network_key": "eth_sepolia"
-		}
-	}`)
-
-	_, _, err := parseMetadata(data, 11155111)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}

--- a/go-sdk/packages/gosev/registry/registry.go
+++ b/go-sdk/packages/gosev/registry/registry.go
@@ -11,6 +11,9 @@ import (
 //go:embed metadata.json
 var metadataJSON []byte
 
+// Added for backward compatibility.
+var ByChainId = New
+
 // New loads the network configuration for the given chain ID.
 // Returns an error if the chain ID is not found or data is invalid.
 func New(chainID uint64) (*Network, error) {

--- a/go-sdk/packages/gosev/registry/registry.go
+++ b/go-sdk/packages/gosev/registry/registry.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"github.com/automata-network/amd-sev-snp-attestation-sdk/contracts/deployments"
 )
@@ -12,177 +11,19 @@ import (
 //go:embed metadata.json
 var metadataJSON []byte
 
-var (
-	registryOnce      sync.Once
-	networks          map[string]*Network  // key -> Network
-	networksByChainID map[uint64]*Network  // chainID -> Network
-	defaultNetworkKey string
-	initError         error
-)
-
-// initRegistry initializes the network registry from embedded files
-func initRegistry() {
-	registryOnce.Do(func() {
-		networks = make(map[string]*Network)
-		networksByChainID = make(map[uint64]*Network)
-
-		// Parse metadata
-		metadataMap, defaultKey, err := parseMetadata(metadataJSON)
-		if err != nil {
-			initError = fmt.Errorf("failed to parse metadata: %w", err)
-			return
-		}
-		defaultNetworkKey = defaultKey
-
-		// Load each network's deployment files
-		for key, meta := range metadataMap {
-			chainIDStr := strconv.FormatUint(meta.ChainID, 10)
-
-			// Read SEV deployment from embedded FS
-			sevPath := fmt.Sprintf("%s.json", chainIDStr)
-			sevData, err := deployments.FS.ReadFile(sevPath)
-			if err != nil {
-				// Network might not have deployment yet, skip
-				continue
-			}
-
-			// Parse network
-			network, err := parseNetwork(key, meta, sevData)
-			if err != nil {
-				continue
-			}
-
-			networks[key] = network
-			networksByChainID[meta.ChainID] = network
-		}
-	})
-}
-
-// All returns all registered networks
-func All() ([]*Network, error) {
-	initRegistry()
-	if initError != nil {
-		return nil, initError
-	}
-
-	result := make([]*Network, 0, len(networks))
-	for _, n := range networks {
-		result = append(result, n)
-	}
-	return result, nil
-}
-
-// ByKey returns a network by its key (e.g., "eth_sepolia")
-func ByKey(key string) (*Network, error) {
-	initRegistry()
-	if initError != nil {
-		return nil, initError
-	}
-
-	key = normalizeNetworkKey(key)
-	if n, ok := networks[key]; ok {
-		return n, nil
-	}
-	return nil, fmt.Errorf("network not found: %s", key)
-}
-
-// ByChainID returns a network by its chain ID
-func ByChainID(chainID uint64) (*Network, error) {
-	initRegistry()
-	if initError != nil {
-		return nil, initError
-	}
-
-	if n, ok := networksByChainID[chainID]; ok {
-		return n, nil
-	}
-	return nil, fmt.Errorf("network not found for chain ID: %d", chainID)
-}
-
-// Default returns the default network (automata_testnet)
-func Default() (*Network, error) {
-	initRegistry()
-	if initError != nil {
-		return nil, initError
-	}
-
-	return ByKey(defaultNetworkKey)
-}
-
-// Testnets returns all testnet networks
-func Testnets() ([]*Network, error) {
-	all, err := All()
+// New loads the network configuration for the given chain ID.
+// Returns an error if the chain ID is not found or data is invalid.
+func New(chainID uint64) (*Network, error) {
+	key, meta, err := parseMetadata(metadataJSON, chainID)
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]*Network, 0)
-	for _, n := range all {
-		if n.Testnet {
-			result = append(result, n)
-		}
-	}
-	return result, nil
-}
-
-// Keys returns all network keys
-func Keys() ([]string, error) {
-	initRegistry()
-	if initError != nil {
-		return nil, initError
-	}
-
-	keys := make([]string, 0, len(networks))
-	for k := range networks {
-		keys = append(keys, k)
-	}
-	return keys, nil
-}
-
-// ChainIDs returns all chain IDs
-func ChainIDs() ([]uint64, error) {
-	initRegistry()
-	if initError != nil {
-		return nil, initError
-	}
-
-	ids := make([]uint64, 0, len(networksByChainID))
-	for id := range networksByChainID {
-		ids = append(ids, id)
-	}
-	return ids, nil
-}
-
-// MustByKey returns a network by key or panics
-func MustByKey(key string) *Network {
-	n, err := ByKey(key)
+	chainIDStr := strconv.FormatUint(chainID, 10)
+	sevData, err := deployments.FS.ReadFile(chainIDStr + ".json")
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("no deployment found for chain ID %d: %w", chainID, err)
 	}
-	return n
-}
 
-// MustByChainID returns a network by chain ID or panics
-func MustByChainID(chainID uint64) *Network {
-	n, err := ByChainID(chainID)
-	if err != nil {
-		panic(err)
-	}
-	return n
+	return parseNetwork(key, meta, sevData)
 }
-
-// MustDefault returns the default network or panics
-func MustDefault() *Network {
-	n, err := Default()
-	if err != nil {
-		panic(err)
-	}
-	return n
-}
-
-// Common network accessors for convenience
-var (
-	EthereumSepolia = func() *Network { return MustByKey("eth_sepolia") }
-	EthereumHoodi   = func() *Network { return MustByKey("eth_hoodi") }
-	AutomataTestnet = func() *Network { return MustByKey("automata_testnet") }
-)

--- a/go-sdk/packages/gosev/registry/registry_test.go
+++ b/go-sdk/packages/gosev/registry/registry_test.go
@@ -1,0 +1,85 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestNew_EthereumSepolia(t *testing.T) {
+	net, err := New(11155111)
+	if err != nil {
+		t.Fatalf("New(11155111) error: %v", err)
+	}
+	if net.Key != "eth_sepolia" {
+		t.Errorf("Key = %q, want %q", net.Key, "eth_sepolia")
+	}
+	if net.ChainID != 11155111 {
+		t.Errorf("ChainID = %d, want 11155111", net.ChainID)
+	}
+	if net.DisplayName != "Ethereum Sepolia" {
+		t.Errorf("DisplayName = %q, want %q", net.DisplayName, "Ethereum Sepolia")
+	}
+	if !net.Testnet {
+		t.Error("Testnet = false, want true")
+	}
+	if net.DefaultRpcUrl() == "" {
+		t.Error("DefaultRpcUrl() returned empty string")
+	}
+	if net.DefaultExplorer() == "" {
+		t.Error("DefaultExplorer() returned empty string")
+	}
+	if net.VerifierAddress() == (common.Address{}) {
+		t.Error("VerifierAddress() returned zero address")
+	}
+}
+
+func TestNew_AutomataTestnet(t *testing.T) {
+	net, err := New(1398243)
+	if err != nil {
+		t.Fatalf("New(1398243) error: %v", err)
+	}
+	if net.Key != "automata_testnet" {
+		t.Errorf("Key = %q, want %q", net.Key, "automata_testnet")
+	}
+}
+
+func TestNew_EthereumHoodi(t *testing.T) {
+	net, err := New(560048)
+	if err != nil {
+		t.Fatalf("New(560048) error: %v", err)
+	}
+	if net.Key != "eth_hoodi" {
+		t.Errorf("Key = %q, want %q", net.Key, "eth_hoodi")
+	}
+}
+
+func TestNew_NotFound(t *testing.T) {
+	_, err := New(999999999)
+	if err == nil {
+		t.Fatal("expected error for unknown chain ID")
+	}
+}
+
+func TestNew_NoDeployment(t *testing.T) {
+	_, err := New(17000)
+	if err == nil {
+		t.Fatal("expected error for chain ID not in metadata")
+	}
+}
+
+func TestNew_AllDeployedChainsHaveVerifier(t *testing.T) {
+	chainIDs := []uint64{11155111, 560048, 1398243}
+	for _, id := range chainIDs {
+		t.Run(fmt.Sprintf("chain_%d", id), func(t *testing.T) {
+			net, err := New(id)
+			if err != nil {
+				t.Fatalf("New(%d) error: %v", id, err)
+			}
+			if net.VerifierAddress() == (common.Address{}) {
+				t.Errorf("chain %d (%s) has zero verifier address", id, net.Key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request significantly refactors the network registry logic in the `go-sdk/packages/gosev/registry` package to simplify its API and improve test coverage and validation. The previous global, registry-based approach is replaced with a stateless function for loading network configuration by chain ID, and comprehensive unit tests are introduced for both parsing and registry logic.

**Registry Refactor and API Simplification:**

- The global registry pattern and related functions (`All`, `ByKey`, `ByChainID`, etc.) in `registry.go` are removed in favor of a single `New(chainID uint64) (*Network, error)` function, which loads and validates network configuration for a given chain ID on demand. This reduces complexity and improves maintainability.

**Parsing Logic Improvements:**

- The `parseMetadata` function in `parser.go` is rewritten to return only the network entry matching a specific `chainID`, removing normalization and default key logic, and improving error handling for invalid data.
- The `parseSevDeployment` function now validates that the `VERIFIER` address is a valid hex address using `common.IsHexAddress`, providing clearer errors for invalid or missing addresses.

**Test Coverage:**

- New unit tests are added in `parser_test.go` to cover valid and invalid cases for both `parseSevDeployment` and `parseMetadata`, ensuring robust parsing and error handling.
- New tests in `registry_test.go` verify that `New` correctly loads configuration for known chain IDs, handles missing or invalid deployments, and ensures all deployed chains have valid verifier addresses.

**Code Cleanup:**

- Unused imports and utility functions (such as `normalizeNetworkKey`) are removed from `parser.go` and `registry.go` to streamline the codebase. [[1]](diffhunk://#diff-2a321bbd4fde1ec605c00483ea29fc1c41150f8222926754ba12d7defa37c307L7) [[2]](diffhunk://#diff-2a321bbd4fde1ec605c00483ea29fc1c41150f8222926754ba12d7defa37c307L68-R93) [[3]](diffhunk://#diff-095df6df10d62548c4235d276044568fa7b7a2c01b0e05683faaaf520b16f13cL7-L188)

These changes make the registry logic more modular, testable, and easier to use for clients who need to load network configuration by chain ID.